### PR TITLE
Fix: 익명 로그인 생성 날짜와 최종 로그인 날짜 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Xcode
+*.xcodeproj/xcuserdata/
+*.xcodeproj/project.xcworkspace/xcuserdata/
+*.xcworkspace/xcuserdata/
+DerivedData/
+build/
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+Pods/
+
+# SPM
+.build/
+Package.resolved
+
+# oh-my-claudecode
+.omc/
+
+# Claude Code
+.claude/
+
+# OS
+.DS_Store
+*.swp
+*~
+
+# Firebase
+GoogleService-Info.plist
+
+# Secrets
+*.env
+*.pem
+*.p12
+*.key

--- a/BanGiDa/Application/DIContainer.swift
+++ b/BanGiDa/Application/DIContainer.swift
@@ -48,6 +48,13 @@ final class AppDIContainer {
             return CheckUserRegistrationUseCaseImpl(userRepository: userRepository)
         }
         
+        container.register(UpdateLastSeenAtUseCase.self) { resolver in
+            guard let userRepository = resolver.resolve(UserRepository.self) else {
+                fatalError("UserRepository dependency has not been registered.")
+            }
+            return UpdateLastSeenAtUseCaseImpl(userRepository: userRepository)
+        }
+
         container.register(UpdateNicknameUseCase.self) { resolver in
             guard let userRepository = resolver.resolve(UserRepository.self) else {
                 fatalError("UserRepository dependency has not been registered.")

--- a/BanGiDa/Application/SceneDelegate.swift
+++ b/BanGiDa/Application/SceneDelegate.swift
@@ -13,6 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     @Injected private var checkUserRegistrationUseCase: CheckUserRegistrationUseCase
     @Injected private var createAuthUserUseCase: CreateAuthUserUseCase
+    @Injected private var updateLastSeenAtUseCase: UpdateLastSeenAtUseCase
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -48,6 +49,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        updateLastSeenAt()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
@@ -65,6 +67,16 @@ private extension SceneDelegate {
                 try await createAuthUserUseCase.execute()
             } catch {
                 print("checkUserRegistration Error: ", error)
+            }
+        }
+    }
+
+    func updateLastSeenAt() {
+        Task {
+            do {
+                try await updateLastSeenAtUseCase.execute()
+            } catch {
+                print("updateLastSeenAt Error: ", error)
             }
         }
     }

--- a/BanGiDa/UseCase/User/CheckUserRegistrationUseCase.swift
+++ b/BanGiDa/UseCase/User/CheckUserRegistrationUseCase.swift
@@ -21,12 +21,6 @@ public final class CheckUserRegistrationUseCaseImpl: CheckUserRegistrationUseCas
     public func execute() async throws -> Bool {
         guard let uid = userRepository.loadUID() else { return false }
         
-        let result = try await userRepository.checkRegistration(uid: uid)
-        
-        if result {
-            try await userRepository.updateLastSeenAt()
-        }
-        
-        return result
+        return try await userRepository.checkRegistration(uid: uid)
     }
 }

--- a/BanGiDa/UseCase/User/UpdateLastSeenAtUseCase.swift
+++ b/BanGiDa/UseCase/User/UpdateLastSeenAtUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  UpdateLastSeenAtUseCase.swift
+//  BanGiDa
+//
+//  Created by 홍석준 on 3/28/26.
+//
+
+import Foundation
+
+public protocol UpdateLastSeenAtUseCase {
+    func execute() async throws
+}
+
+public final class UpdateLastSeenAtUseCaseImpl: UpdateLastSeenAtUseCase {
+    private let userRepository: UserRepository
+
+    public init(userRepository: UserRepository) {
+        self.userRepository = userRepository
+    }
+
+    public func execute() async throws {
+        guard userRepository.loadUID() != nil else { return }
+        try await userRepository.updateLastSeenAt()
+    }
+}


### PR DESCRIPTION
## Summary
- `createAt`(생성 날짜)과 `lastSeenAt`(최종 로그인 날짜)를 명확히 분리
- `createAt`: 계정 생성 시 1회만 설정 (기존과 동일)
- `lastSeenAt`: 앱 진입(foreground) 시마다 업데이트되도록 `sceneWillEnterForeground`에서 호출
- `CheckUserRegistrationUseCase`에서 중복 `updateLastSeenAt` 호출 제거
- `UpdateLastSeenAtUseCase` 신규 추가 및 DI 등록
- `.gitignore` 추가 (.omc, .claude, DerivedData 등 불필요 파일 제외)

## 변경 파일
- `BanGiDa/UseCase/User/UpdateLastSeenAtUseCase.swift` (신규)
- `BanGiDa/Application/SceneDelegate.swift`
- `BanGiDa/Application/DIContainer.swift`
- `BanGiDa/UseCase/User/CheckUserRegistrationUseCase.swift`
- `.gitignore` (신규)

## Test plan
- [ ] 최초 설치 후 Firestore에서 `createAt`과 `lastSeenAt`이 동일한 값으로 생성되는지 확인
- [ ] 앱 종료 후 재실행 시 `lastSeenAt`만 업데이트되고 `createAt`은 변경되지 않는지 확인
- [ ] 백그라운드 → 포그라운드 전환 시 `lastSeenAt`이 업데이트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)