### PR TITLE
fix(domain): make SaveDiary atomic and propagate image write errors

### DIFF
--- a/BanGiDa/Data/LocalStorage/ImageRepositoryImpl.swift
+++ b/BanGiDa/Data/LocalStorage/ImageRepositoryImpl.swift
@@ -18,8 +18,18 @@ final class ImageRepositoryImpl: ImageRepository {
         documentManager.loadImageDataFromDocument(fileName: fileName)
     }
 
-    func saveImageData(fileName: String, data: Data) {
-        documentManager.saveImageDataFromDocument(fileName: fileName, image: data)
+    func saveImageData(fileName: String, data: Data) throws {
+        documentManager.createImagesDirectoryPath()
+
+        guard let documentDirectory = documentManager.documentDirectoryPath() else {
+            throw DocumentError.fetchDirectoryPathError
+        }
+
+        let fileURL = documentDirectory
+            .appendingPathComponent("images")
+            .appendingPathComponent(fileName)
+
+        try data.write(to: fileURL)
     }
 
     func removeImage(fileName: String) {

--- a/BanGiDa/Domain/Repository/ImageRepository.swift
+++ b/BanGiDa/Domain/Repository/ImageRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol ImageRepository {
     func loadImageData(fileName: String) -> Data?
-    func saveImageData(fileName: String, data: Data)
+    func saveImageData(fileName: String, data: Data) throws
     func removeImage(fileName: String)
     func removeAll()
 }

--- a/BanGiDa/Domain/UseCase/Diary/SaveDiaryUseCase.swift
+++ b/BanGiDa/Domain/UseCase/Diary/SaveDiaryUseCase.swift
@@ -40,7 +40,7 @@ final class SaveDiaryUseCaseImpl: SaveDiaryUseCase {
         }
 
         let fileName = "\(saved.id).jpg"
-        imageRepository.saveImageData(fileName: fileName, data: photoData)
+        try imageRepository.saveImageData(fileName: fileName, data: photoData)
 
         var updated = saved
         updated.photoFileName = fileName

--- a/BanGiDa/Domain/UseCase/Diary/SaveDiaryUseCase.swift
+++ b/BanGiDa/Domain/UseCase/Diary/SaveDiaryUseCase.swift
@@ -21,7 +21,7 @@ final class SaveDiaryUseCaseImpl: SaveDiaryUseCase {
     }
 
     func execute(type: DiaryType, date: Date, content: String, animalName: String, photoData: Data?, alarmTitle: String?, repeatRule: AlarmRepeat) throws -> DiaryEntry {
-        let entry = DiaryEntry(
+        var entry = DiaryEntry(
             id: UUID().uuidString,
             type: type,
             date: date,
@@ -33,18 +33,14 @@ final class SaveDiaryUseCaseImpl: SaveDiaryUseCase {
             repeatRule: repeatRule
         )
 
-        let saved = try diaryRepository.save(entry)
-
         guard let photoData = photoData else {
-            return saved
+            return try diaryRepository.save(entry)
         }
 
-        let fileName = "\(saved.id).jpg"
+        let fileName = "\(entry.id).jpg"
+        entry.photoFileName = fileName
         try imageRepository.saveImageData(fileName: fileName, data: photoData)
 
-        var updated = saved
-        updated.photoFileName = fileName
-        try diaryRepository.update(updated)
-        return updated
+        return try diaryRepository.save(entry)
     }
 }

--- a/BanGiDa/Domain/UseCase/Diary/UpdateDiaryUseCase.swift
+++ b/BanGiDa/Domain/UseCase/Diary/UpdateDiaryUseCase.swift
@@ -23,7 +23,7 @@ final class UpdateDiaryUseCaseImpl: UpdateDiaryUseCase {
     func execute(entry: DiaryEntry, photoData: Data?) throws {
         if let photoData = photoData {
             let fileName = "\(entry.id).jpg"
-            imageRepository.saveImageData(fileName: fileName, data: photoData)
+            try imageRepository.saveImageData(fileName: fileName, data: photoData)
             var updatedEntry = entry
             updatedEntry.photoFileName = fileName
             try diaryRepository.update(updatedEntry)

--- a/BanGiDa/Domain/UseCase/Image/SaveImageUseCase.swift
+++ b/BanGiDa/Domain/UseCase/Image/SaveImageUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol SaveImageUseCase {
-    func execute(fileName: String, data: Data)
+    func execute(fileName: String, data: Data) throws
 }
 
 final class SaveImageUseCaseImpl: SaveImageUseCase {
@@ -18,7 +18,7 @@ final class SaveImageUseCaseImpl: SaveImageUseCase {
         self.imageRepository = imageRepository
     }
 
-    func execute(fileName: String, data: Data) {
-        imageRepository.saveImageData(fileName: fileName, data: data)
+    func execute(fileName: String, data: Data) throws {
+        try imageRepository.saveImageData(fileName: fileName, data: data)
     }
 }

--- a/BanGiDa/Presentation/Main/Setting/View/SettingViewController.swift
+++ b/BanGiDa/Presentation/Main/Setting/View/SettingViewController.swift
@@ -287,7 +287,11 @@ extension SettingViewController: CropViewControllerDelegate {
         mainView.profileView.imageView.image = image
         if image != UIImage(named: "BasicDog"),
            let imageData = image.jpegData(compressionQuality: 0.8) {
-            saveImageUseCase.execute(fileName: "UserProfile.jpg", data: imageData)
+            do {
+                try saveImageUseCase.execute(fileName: "UserProfile.jpg", data: imageData)
+            } catch {
+                showAlert(message: "프로필 이미지 저장에 실패했습니다.")
+            }
         }
         dismiss(animated: true)
     }


### PR DESCRIPTION
## Summary
- \`ImageRepository.saveImageData(fileName:data:)\`를 \`throws\`로 변경해 디스크 에러 전파
- \`ImageRepositoryImpl\`에서 \`try?\` 제거, 실 에러 throw
- \`SaveDiaryUseCase\`: **이미지 저장 먼저 → Realm 1회 write** 구조로 변경 (기존 2-write에서 1-write로)
- 관련 전파: \`UpdateDiaryUseCase\`, \`SaveImageUseCase\`, \`SettingViewController\` (UserProfile 저장 실패 시 alert)

## Background
코드리뷰 P0 — 기존 구조는:
1. Realm save (photoFileName=nil) — write 1
2. 이미지 저장 (throws 없음, 에러 무시)
3. Realm update (photoFileName 세팅) — write 2

step 2/3 사이 크래시 시 사진 없는 orphan DiaryEntry 남음. 이제 이미지 실패 시 Realm 쓰기 전에 throw, 성공 시 photoFileName 포함 1회 write.

## Test plan
- [ ] 사진 포함 일지 저장 시 정상 저장되는지 확인
- [ ] 사진 없이 저장 시 정상 저장되는지 확인
- [ ] (이론상) 디스크 full 상황에서 orphan 엔트리가 생기지 않는지 확인
- [ ] 프로필 이미지 저장 실패 시 알림 표시되는지 확인
- [ ] 일지 수정(사진 변경) 경로 정상 동작 확인 (UpdateDiaryUseCase)

Ref: \`BanGiDa-CodeReview-2026-04-17.md\` P0 #2