### PR TITLE
refactor(alarm): unify alarm update path via UpdateAlarmUseCase

### DIFF
--- a/BanGiDa/Application/DIContainer.swift
+++ b/BanGiDa/Application/DIContainer.swift
@@ -177,6 +177,13 @@ final class AppDIContainer {
             )
         }
 
+        container.register(UpdateAlarmUseCase.self) { resolver in
+            UpdateAlarmUseCaseImpl(
+                diaryRepository: resolver.force(DiaryRepository.self),
+                notificationRepository: resolver.force(NotificationRepository.self)
+            )
+        }
+
         // MARK: - Backup UseCases
 
         container.register(CreateBackupUseCase.self) { resolver in

--- a/BanGiDa/Domain/UseCase/Alarm/UpdateAlarmUseCase.swift
+++ b/BanGiDa/Domain/UseCase/Alarm/UpdateAlarmUseCase.swift
@@ -1,0 +1,39 @@
+//
+//  UpdateAlarmUseCase.swift
+//  BanGiDa
+//
+//  Created by OpenAI Codex on 2026/04/17.
+//
+
+import Foundation
+
+protocol UpdateAlarmUseCase {
+    func execute(entry: DiaryEntry) throws -> DiaryEntry
+}
+
+final class UpdateAlarmUseCaseImpl: UpdateAlarmUseCase {
+    private let diaryRepository: DiaryRepository
+    private let notificationRepository: NotificationRepository
+
+    init(diaryRepository: DiaryRepository, notificationRepository: NotificationRepository) {
+        self.diaryRepository = diaryRepository
+        self.notificationRepository = notificationRepository
+    }
+
+    func execute(entry: DiaryEntry) throws -> DiaryEntry {
+        try diaryRepository.update(entry)
+        notificationRepository.remove(identifier: entry.id)
+
+        if entry.date > Date() || entry.repeatRule != .none {
+            notificationRepository.schedule(
+                identifier: entry.id,
+                title: entry.alarmTitle ?? entry.animalName,
+                body: entry.content,
+                date: entry.date,
+                repeatRule: entry.repeatRule
+            )
+        }
+
+        return entry
+    }
+}

--- a/BanGiDa/Presentation/Main/Alarm/ViewModel/AlarmViewModel.swift
+++ b/BanGiDa/Presentation/Main/Alarm/ViewModel/AlarmViewModel.swift
@@ -11,9 +11,7 @@ import Foundation
 final class AlarmViewModel {
     @Injected private var analyticsRepository: AnalyticsRepository
     @Injected private var saveAlarmUseCase: SaveAlarmUseCase
-    @Injected private var updateDiaryUseCase: UpdateDiaryUseCase
-    @Injected private var scheduleNotificationUseCase: ScheduleNotificationUseCase
-    @Injected private var removeNotificationUseCase: RemoveNotificationUseCase
+    @Injected private var updateAlarmUseCase: UpdateAlarmUseCase
     @Injected private var fetchDiariesByDateUseCase: FetchDiariesByDateUseCase
     @Injected private var findDiaryByIDUseCase: FindDiaryByIDUseCase
     @Injected private var userPreferencesUseCase: UserPreferencesUseCase
@@ -60,7 +58,7 @@ final class AlarmViewModel {
             updatedEntry.repeatRule = repeatRule
 
             do {
-                try updateDiaryUseCase.execute(entry: updatedEntry, photoData: nil)
+                _ = try updateAlarmUseCase.execute(entry: updatedEntry)
             } catch {
                 print("error: \(error)")
                 let userInfo = ["class": "\(self)", "method": "\(#function)"]
@@ -68,17 +66,6 @@ final class AlarmViewModel {
             }
 
             fetchData(date: currentDate)
-
-            removeNotificationUseCase.execute(identifier: existing.id)
-            if date > Date() {
-                scheduleNotificationUseCase.execute(
-                    identifier: existing.id,
-                    title: titleText,
-                    body: content,
-                    date: date,
-                    repeatRule: repeatRule
-                )
-            }
         } else {
             let date = dateText.toDateAlarm() ?? Date()
             let animalName = userPreferencesUseCase.getPetName() ?? "신원 미상"


### PR DESCRIPTION
## Summary
- \`UpdateAlarmUseCase\` 신설: \`SaveAlarmUseCase\`와 동일한 스케줄 조건 \`date > now || repeatRule != .none\` 적용
- \`DIContainer\`에 등록 (기존 UseCase들과 동일 패턴)
- \`AlarmViewModel.saveData\` 수정 경로를 단일 UseCase 호출로 통일 — 기존 \`updateDiaryUseCase\` + \`removeNotificationUseCase\` + \`scheduleNotificationUseCase\` 3단 호출 제거

## Background
코드리뷰 P1 — 신규 등록(\`SaveAlarmUseCase\`)은 \`date > now || repeatRule != .none\` 조건, 수정은 \`date > now\`만 검사 → 과거 날짜 \`.daily\` 반복 알림을 수정하면 반복이 사라짐.

## Test plan
- [ ] 과거 날짜 + \`.daily\` 반복 알람 수정 시 반복 스케줄이 유지되는지 확인
- [ ] 미래 날짜 + \`.none\` 알람 수정 시 기존과 동일 동작 확인
- [ ] 미래 날짜 + 반복 있음 수정 시 정상 동작 확인
- [ ] 알람 신규 생성 경로(SaveAlarmUseCase)는 영향 없는지 확인

Ref: \`BanGiDa-CodeReview-2026-04-17.md\` P1 (알람 수정 반복 조건 불일치)