### PR TITLE
fix(domain): clear pending notifications before restoring from backup

### DIFF
--- a/BanGiDa/Domain/UseCase/Alarm/RestoreNotificationsUseCase.swift
+++ b/BanGiDa/Domain/UseCase/Alarm/RestoreNotificationsUseCase.swift
@@ -21,6 +21,7 @@ final class RestoreNotificationsUseCaseImpl: RestoreNotificationsUseCase {
     }
 
     func execute() {
+        notificationRepository.removeAllPending()
         let alarms = diaryRepository.fetchByType(.alarm)
         for alarm in alarms where alarm.date > Date() {
             notificationRepository.schedule(


### PR DESCRIPTION
## Summary
- \`RestoreNotificationsUseCase.execute()\` 진입 시 \`notificationRepository.removeAllPending()\` 선행 호출
- 복원 전 기존 pending 알림을 정리해 중복 발송 방지

## Background
코드리뷰 P1 — 기존 구현은 복원 전 pending 알림을 제거하지 않아, 복원 후 \`과거 등록된 알림 + 복원된 알림\` 중복. \`NotificationRepository.removeAllPending()\`은 이미 정의돼 있었으나 호출되지 않았음.

## Test plan
- [ ] 알람이 있는 상태에서 백업 복원 후 NotificationCenter pending 목록에 **복원된 알람만** 존재하는지 확인
- [ ] 알람이 하나도 없는 백업 복원 시 기존 pending이 모두 제거되는지 확인

Ref: \`BanGiDa-CodeReview-2026-04-17.md\` P1 (복원 직후 알림 중복)