### PR TITLE
fix(backup): 복구 완료 후 오류 6 노출 이슈 해결

### DIFF
--- a/BanGiDa/Data/Backup/BackupRepositoryImpl.swift
+++ b/BanGiDa/Data/Backup/BackupRepositoryImpl.swift
@@ -101,8 +101,5 @@ final class BackupRepositoryImpl: BackupRepository {
             realm.deleteAll()
             realm.add(decodedData)
         }
-
-        // Re-create backup file (preserves existing behavior)
-        _ = try documentManager.createBackupFile()
     }
 }

--- a/BanGiDa/Data/LocalStorage/DocumentManager.swift
+++ b/BanGiDa/Data/LocalStorage/DocumentManager.swift
@@ -9,18 +9,41 @@ import UIKit
 import RealmSwift
 import Zip
 
-enum DocumentError: Error {
+enum DocumentError: LocalizedError {
     case createDirectoryError
     case saveImageError
     case removeDirectoryError
     case fetchImagesError
     case fetchZipFileError
     case fetchDirectoryPathError
-    
+
     case compressionFailedError
     case restoreFailedError
-    
+
     case fetchJsonDataError
+
+    var errorDescription: String? {
+        switch self {
+        case .createDirectoryError:
+            return "폴더를 생성하지 못했습니다."
+        case .saveImageError:
+            return "이미지를 저장하지 못했습니다."
+        case .removeDirectoryError:
+            return "폴더를 삭제하지 못했습니다."
+        case .fetchImagesError:
+            return "이미지 파일을 불러오지 못했습니다."
+        case .fetchZipFileError:
+            return "백업 파일을 불러오지 못했습니다."
+        case .fetchDirectoryPathError:
+            return "저장소 경로를 확인하지 못했습니다."
+        case .compressionFailedError:
+            return "백업 파일을 만들지 못했습니다."
+        case .restoreFailedError:
+            return "백업 파일을 복구하지 못했습니다."
+        case .fetchJsonDataError:
+            return "백업 데이터를 읽지 못했습니다."
+        }
+    }
 }
 
 enum CodableError: Error {


### PR DESCRIPTION
## Summary
- 복구 성공 이후 불필요하게 호출되던 `createBackupFile()`을 제거해, 성공한 복구가 `DocumentError.compressionFailedError`(오류 6)로 실패처럼 보이던 문제 수정
- `DocumentError`를 `LocalizedError`로 전환해 \"BanGiDa.DocumentError 오류 N\" 대신 한글 메시지가 노출되도록 개선

## Root cause
`BackupRepositoryImpl.restoreFromFile(_:)`은 zip을 `stagingURL`에만 풀고 `encodedData.json`을 live Documents 경로로 옮기지 않습니다. 그런데 메서드 끝에서 `createBackupFile()`을 다시 호출하며, 해당 함수는 live 경로에 `encodedData.json`과 `images/`가 모두 있어야 통과하는 `isFileExist` 가드를 가지고 있어 항상 `compressionFailedError`를 던졌습니다. 실제 복구(Realm 덮어쓰기, 이미지 이동)는 이미 성공한 뒤라 사용자 입장에서는 \"데이터는 바뀌었는데 실패 알림이 뜨는\" 혼란이 발생했습니다.

## Changes
- `BanGiDa/Data/Backup/BackupRepositoryImpl.swift`
  - 복구 성공 후 zip 재생성을 수행하던 `_ = try documentManager.createBackupFile()` 호출 제거
- `BanGiDa/Data/LocalStorage/DocumentManager.swift`
  - `DocumentError`가 `LocalizedError`를 채택하도록 변경, 각 case에 한글 `errorDescription` 추가

## Test plan
- [ ] 설정 > 백업 > 복구 플로우에서 zip을 선택했을 때 성공 알림이 뜨고, 기존의 \"오류 6\" 문구가 보이지 않는지 확인
- [ ] 임의로 잘못된 zip(예: 확장자만 zip인 빈 파일)을 선택했을 때 한글 에러 메시지가 표시되는지 확인
- [ ] 복구 후 탭바 이동, 알림 재등록이 정상 동작하는지 확인
- [ ] 복구 후 사진, 다이어리 데이터가 모두 반영되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)